### PR TITLE
Internal: add RabbitMQ port to test configurations

### DIFF
--- a/tests/configs/test-config-1.yml
+++ b/tests/configs/test-config-1.yml
@@ -6,5 +6,6 @@ p2p:
 
 rabbitmq:
   host: "rabbitmq"
+  port: 5672
   pub_exchange: "p2p-publish-1"
   sub_exchange: "p2p-subscribe-1"

--- a/tests/configs/test-config-2.yml
+++ b/tests/configs/test-config-2.yml
@@ -9,5 +9,6 @@ p2p:
 
 rabbitmq:
   host: "rabbitmq"
+  port: 5672
   pub_exchange: "p2p-publish-2"
   sub_exchange: "p2p-subscribe-2"


### PR DESCRIPTION
Problem: the Docker images of the P2P service require specifying the RabbitMQ host + port in the configuration files, breaking the tests.
Solution: add the RabbitMQ port in the test config files.