### PR TITLE
Feature: publish with loopback

### DIFF
--- a/tests/configs/test-config-1.yml
+++ b/tests/configs/test-config-1.yml
@@ -2,6 +2,7 @@ p2p:
   topics:
     - test-topic-1
     - test-topic-2
+    - test-topic-loopback
   peers: []
 
 rabbitmq:

--- a/tests/configs/test-config-2.yml
+++ b/tests/configs/test-config-2.yml
@@ -4,6 +4,7 @@ p2p:
   topics:
     - test-topic-1
     - test-topic-2
+    - test-topic-loopback
   peers:
     - "/dns/p2p-service-1/tcp/4025/p2p/QmTXr8ecVWn8DMdDxQktL3YgNrVh7hp33CTMGhN1sqmwRp"
 


### PR DESCRIPTION
Problem: in some cases, we want to send a message on a pubsub topic and receive it on the same node (ex: Aleph message).

Solution: add a `loopback` boolean parameter to `publish`. When set, the client will forward the message to the P2P service and also publish it on the subscription exchange.