### PR TITLE
Solve Rabbitmq double ACK issue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ package_dir =
 # For more information, check out https://semver.org/.
 install_requires =
     aiohttp>=3.8.0
-    aio_pika>=8.0.0<=10.0.0
+    aio_pika>=8.0.0,<10
     importlib-metadata; python_version<"3.8"
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ package_dir =
 # For more information, check out https://semver.org/.
 install_requires =
     aiohttp>=3.8.0
-    aio_pika>=8.0.0
+    aio_pika>=8.0.0<=10.0.0
     importlib-metadata; python_version<"3.8"
 
 

--- a/src/aleph_p2p_client/client.py
+++ b/src/aleph_p2p_client/client.py
@@ -70,7 +70,8 @@ class AlephP2PMessageQueueClient:
         async with sub_queue.iterator() as queue_iter:
             async for message in queue_iter:
                 yield message
-                await message.ack()
+                if not message.processed:
+                    await message.ack()
 
 
 class AlephP2PHttpClient:

--- a/src/aleph_p2p_client/client.py
+++ b/src/aleph_p2p_client/client.py
@@ -70,6 +70,8 @@ class AlephP2PMessageQueueClient:
         async with sub_queue.iterator() as queue_iter:
             async for message in queue_iter:
                 yield message
+                # This condition prevents double ACK issues given by aiopika and rabbitmq if a lot of messages
+                # are received
                 if not message.processed:
                     await message.ack()
 


### PR DESCRIPTION
Seems that with a huge amount of P2P messages got from RabbitMQ, the message is sending an ACK more than one time:

```
2025-01-08 15:57:32 [ERROR] aleph.services.p2p.protocol: Exception in pubsub, reconnecting.
Traceback (most recent call last):
  File "/opt/pyaleph/src/aleph/services/p2p/protocol.py", line 25, in incoming_channel
    async for message in p2p_client.receive_messages(topic):
  File "/opt/venv/lib/python3.12/site-packages/aleph_p2p_client/client.py", line 158, in receive_messages
    async for message in self.mq_client.receive_messages(topic):
  File "/opt/venv/lib/python3.12/site-packages/aleph_p2p_client/client.py", line 73, in receive_messages
    await message.ack()
  File "/opt/venv/lib/python3.12/site-packages/aio_pika/message.py", line 473, in ack
    raise MessageProcessError("Message already processed", self)
aio_pika.exceptions.MessageProcessError: ('Message already processed', IncomingMessage:{'app_id': None,
 'body_size': 647,
 'cluster_id': '',
 'consumer_tag': 'ctag1.6f293979a7e344c49eba7c4df0fdeed8',
 'content_encoding': None,
 'content_type': None,
 'correlation_id': None,
 'delivery_mode': <DeliveryMode.NOT_PERSISTENT: 1>,
 'delivery_tag': 3059,
 'exchange': 'p2p-subscribe',
 'expiration': None,
 'headers': {},
 'message_id': None,
 'priority': 0,
 'redelivered': False,
 'reply_to': None,
 'routing_key': 'p2p.ALEPH-TEST.QmZkurbY2G2hWay59yiTgQNaQxHSNzKZFt2jbnwJhQcKgV',
 'timestamp': None,
 'type': 'None',
 'user_id': None})
 ```
 
 This fix try to solve it, checking first if the message isn't marked as processed yet.