### PR TITLE
Fix: support TLS for HTTP and MQ connections

### DIFF
--- a/src/aleph_p2p_client/client.py
+++ b/src/aleph_p2p_client/client.py
@@ -1,5 +1,6 @@
+import ssl
 from dataclasses import dataclass
-from typing import AsyncIterator, Dict
+from typing import Any, AsyncIterator, Dict, Optional
 
 import aio_pika
 import aiohttp
@@ -182,9 +183,16 @@ async def declare_mq_objects(
     mq_password: str,
     mq_pub_exchange_name: str,
     mq_sub_exchange_name: str,
+    mq_use_tls: bool = False,
+    mq_ssl_options: Optional[Dict[str, Any]] = None,
 ):
     connection = await aio_pika.connect_robust(
-        host=mq_host, port=mq_port, login=mq_username, password=mq_password
+        host=mq_host,
+        port=mq_port,
+        login=mq_username,
+        password=mq_password,
+        ssl=mq_use_tls,
+        ssl_options=mq_ssl_options,
     )
     try:
         channel = await connection.channel()
@@ -221,15 +229,30 @@ async def make_p2p_service_client(
     mq_port: int = DEFAULT_MQ_PORT,
     mq_pub_exchange_name: str = DEFAULT_PUB_EXCHANGE_NAME,
     mq_sub_exchange_name: str = DEFAULT_SUB_EXCHANGE_NAME,
+    mq_use_tls: bool = False,
+    mq_ssl_options: Optional[Dict[str, Any]] = None,
     http_host: str = DEFAULT_HTTP_HOST,
     http_port: int = DEFAULT_HTTP_PORT,
     http_timeout: float = 30.0,
+    http_use_tls: bool = False,
+    http_ssl_context: Optional[ssl.SSLContext] = None,
 ) -> AlephP2PServiceClient:
 
-    http_session = aiohttp.ClientSession(
-        base_url=f"http://{http_host}:{http_port}/",
-        timeout=aiohttp.ClientTimeout(total=http_timeout),
-    )
+    if http_use_tls:
+        http_scheme = "https"
+        connector = aiohttp.TCPConnector(
+            ssl=http_ssl_context if http_ssl_context is not None else True
+        )
+        http_session = aiohttp.ClientSession(
+            base_url=f"{http_scheme}://{http_host}:{http_port}/",
+            connector=connector,
+            timeout=aiohttp.ClientTimeout(total=http_timeout),
+        )
+    else:
+        http_session = aiohttp.ClientSession(
+            base_url=f"http://{http_host}:{http_port}/",
+            timeout=aiohttp.ClientTimeout(total=http_timeout),
+        )
     http_client = AlephP2PHttpClient(http_session=http_session)
 
     try:
@@ -244,6 +267,8 @@ async def make_p2p_service_client(
             mq_password=mq_password,
             mq_pub_exchange_name=mq_pub_exchange_name,
             mq_sub_exchange_name=mq_sub_exchange_name,
+            mq_use_tls=mq_use_tls,
+            mq_ssl_options=mq_ssl_options,
         )
     except BaseException:
         await http_client.close()


### PR DESCRIPTION
## Summary

Fixes security finding **M1** from the internal review: the client previously hardcoded plaintext `http://` for the aiohttp base URL and used plaintext AMQP for `aio_pika.connect_robust(...)`. When the P2P daemons are not co-located with the client, credentials (including the MQ password) traverse the network in cleartext.

This PR adds opt-in TLS support to `make_p2p_service_client` so cross-host deployments can encrypt both transports.

## New parameters

`make_p2p_service_client` gains four optional parameters:

- `http_use_tls: bool = False` - when `True`, the base URL uses `https://` instead of `http://`.
- `http_ssl_context: Optional[ssl.SSLContext] = None` - optional custom `SSLContext`. When `http_use_tls=True` and this is `None`, aiohttp's `TCPConnector` receives `ssl=True` (default verifying context). When provided, it is passed through verbatim.
- `mq_use_tls: bool = False` - plumbed to `aio_pika.connect_robust(..., ssl=...)`.
- `mq_ssl_options: Optional[Dict[str, Any]] = None` - plumbed to `aio_pika.connect_robust(..., ssl_options=...)`. This is aio_pika's native dict-based API; no translation layer is added.

The MQ parameters are also threaded through `declare_mq_objects` so it remains usable directly.

## Behavior change

**None for existing callers.** With both `http_use_tls=False` and `mq_use_tls=False` (the defaults), the factory takes the same code path as before: plaintext `http://` base URL and `aio_pika.connect_robust` called with `ssl=False, ssl_options=None`. Existing localhost callers are unaffected.

## Out of scope

Credential defaults (e.g. removing `guest:guest`) and HTTP request timeouts are intentionally left for separate PRs.

## Test plan

- [ ] Existing localhost deployment continues to work with the call site unchanged (defaults preserve plaintext behavior).
- [ ] Setting `http_use_tls=True` against an HTTPS-enabled P2P daemon successfully completes `identify()`.
- [ ] Setting `mq_use_tls=True` (with appropriate `mq_ssl_options` and an AMQPS-enabled broker) successfully publishes and subscribes.
- [ ] Providing a custom `http_ssl_context` (e.g. with a private CA) is honored by the connector.