### PR TITLE
Fix: bump aiohttp floor to 3.10.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ package_dir =
 # new major versions. This works if the required packages follow Semantic Versioning.
 # For more information, check out https://semver.org/.
 install_requires =
-    aiohttp>=3.8.0
+    aiohttp>=3.10.11
     aio_pika>=8.0.0,<10
     importlib-metadata; python_version<"3.8"
 


### PR DESCRIPTION
## Summary

Fixes security finding **L4**: `setup.cfg` declared `aiohttp>=3.8.0` with no upper bound and no lower bound past CVE-affected releases. Installation could resolve to versions vulnerable to a series of HTTP-parser CVEs.

## CVEs cleared by bumping to >=3.10.11

| CVE | Issue | Fixed in |
|---|---|---|
| CVE-2023-37276 | HTTP request smuggling via Transfer-Encoding whitespace | 3.8.5 |
| CVE-2023-49081 / 49082 | CRLF injection in HTTP headers | 3.9.0 |
| CVE-2024-23829 | HTTP request smuggling | 3.9.2 |
| CVE-2024-30251 | Infinite loop in multipart parser | 3.9.4 |
| CVE-2024-52303 | Memory leak in multipart parser | 3.10.11 |
| CVE-2024-52304 | HTTP request smuggling | 3.10.11 |

## Compatibility note

aiohttp 3.10.x requires Python >= 3.8. The package already gates an `importlib_metadata` fallback on `sys.version_info[:2] >= (3, 8)` in `__init__.py`, so the conditional branch becomes dead code — that's harmless and can be cleaned up in a separate PR. Python 3.7 has been EOL since June 2023, so this is not a meaningful regression.

## Test plan

- [ ] `pip install -e .` resolves a non-vulnerable aiohttp.
- [ ] Existing test suite passes against aiohttp 3.10.11.