### PR TITLE
Add PyPI publish workflow on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # setuptools_scm derives the version from git tags; needs full history.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Add `.github/workflows/publish.yml` that triggers on any tag push, builds sdist+wheel with `python -m build`, and publishes to PyPI via the trusted-publisher (OIDC) flow.
- Modeled on the `publish.yml` from [aleph-message](https://github.com/aleph-im/aleph-message), adapted for this project's setuptools + setuptools_scm build (vs. hatch).
- `fetch-depth: 0` is set so setuptools_scm can derive the version from the tag.

## Required setup on PyPI / GitHub before the first release
1. **PyPI trusted publisher** for project `aleph-p2p-client`, pointing at:
   - Repository: `aleph-im/p2p-service-client-python`
   - Workflow: `publish.yml`
   - Environment: `pypi`
   - (If the project does not yet exist on PyPI, use the "pending" trusted publisher flow.)
2. **GitHub environment** named `pypi` (repo Settings → Environments). Add reviewers or a tag protection rule here if desired.

## Test plan
- [ ] Confirm trusted publisher is configured on PyPI for this project + workflow + environment.
- [ ] Confirm a `pypi` environment exists in repo settings.
- [ ] Push a test tag (e.g. on a fork or to TestPyPI first) and verify the workflow builds and publishes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)